### PR TITLE
Fixes Error on line 396

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -393,7 +393,7 @@
 
       ## 1. Without women and underrepresented groups, AI can have terrible consequences:
 
-      - When Siri was first introduced into the iPhone it was not able to understand women's voices because it had not been tuned to recognize higher pitch voices which women typically have. The developers of the speech recognition engine Siri uses programmed their own biases into the algorithms - as older men they were suffering from high frequency hearing loss. This is why it's so important to employ diverse teams of software developers.
+      - When Siri was first introduced into the iPhone it was not able to understand women's voices because it had not been tuned to recognize higher pitch voices which women typically have. The developers of the speech recognition engine Siri programmed their own biases into the algorithms - as older men they were suffering from high frequency hearing loss. This is why it's so important to employ diverse teams of software developers.
       - An AI system designed by Northpointe in the US to predict the likelihood that an alleged offender will commit another crime in the future was shown to demonstrate racial bias in its predictions.
     </script>
   </section>


### PR DESCRIPTION
Line number  396 has a grammatical error in the second sentence.  This can be fixed by omitting the word 'uses', thus making the statement flow without a hitch.